### PR TITLE
Add bf3 role for BlueField-3 DPU (SOL-VNC agent + nova [dpu])

### DIFF
--- a/ansible/bf3.yml
+++ b/ansible/bf3.yml
@@ -1,0 +1,16 @@
+---
+# Deploy the SOL-VNC agent and render the nova [dpu] config on BlueField-3 DPU
+# compute hosts. Imported from site.yml BEFORE nova.yml so the rendered nova
+# [dpu] override is in place when nova-cell merges its config.
+- name: Apply role bf3
+  gather_facts: false
+  hosts:
+    - "{{ bf3_group | default('compute-bf3') }}"
+    - '&enable_bf3_True'
+  serial: '{{ kolla_serial|default("0") }}'
+  tags:
+    - bf3
+  roles:
+    - role: bf3
+      tags: bf3
+      when: enable_bf3 | bool

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -898,6 +898,9 @@ enable_haproxy_memcached: "no"
 # Additional optional OpenStack features and services are specified here
 enable_aodh: "no"
 enable_barbican: "no"
+# BF3 DPU: deploy the SOL-VNC agent and render the nova [dpu] override on hosts
+# in the bf3_group ('compute-bf3') group. Off by default.
+enable_bf3: "no"
 enable_blazar: "no"
 enable_ceilometer: "no"
 enable_ceilometer_ipmi: "no"

--- a/ansible/roles/bf3/defaults/main.yml
+++ b/ansible/roles/bf3/defaults/main.yml
@@ -1,0 +1,67 @@
+---
+####################
+# BF3 / SOL-VNC agent
+####################
+# Master switch. Set to "yes" in globals.yml to deploy the SOL-VNC agent and
+# render the nova [dpu] config on BlueField-3 DPU compute hosts.
+enable_bf3: "no"
+
+# Ansible group containing the BF3 DPU compute hosts.
+bf3_group: "compute-bf3"
+
+bf3_services:
+  sol-vnc-agent:
+    container_name: "sol_vnc_agent"
+    group: "{{ bf3_group }}"
+    enabled: "{{ enable_bf3 | bool }}"
+    image: "{{ sol_vnc_agent_image_full }}"
+    volumes: "{{ sol_vnc_agent_default_volumes + sol_vnc_agent_extra_volumes }}"
+    dimensions: "{{ sol_vnc_agent_dimensions }}"
+
+####################
+# Docker image
+####################
+# Custom image, not part of the OpenStack release. Defaults to the "latest" tag
+# rather than openstack_tag. Pushed to your existing registry/namespace.
+sol_vnc_agent_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/sol-vnc-agent"
+sol_vnc_agent_tag: "latest"
+sol_vnc_agent_image_full: "{{ sol_vnc_agent_image }}:{{ sol_vnc_agent_tag }}"
+
+sol_vnc_agent_dimensions: "{{ default_container_dimensions }}"
+
+####################
+# Volumes
+####################
+# Mirrors the original run.sh: bind-mount the rendered config to the path the
+# agent reads inside the container, plus the shared SOL socket dir. Host
+# networking and restart policy are applied automatically by kolla_container.
+sol_vnc_agent_default_volumes:
+  - "{{ node_config_directory }}/sol-vnc-agent/config.yaml:/etc/kolla/nova-compute/config.yaml:ro"
+  - "/var/run/sol-vnc:/var/run/sol-vnc"
+  - "/etc/localtime:/etc/localtime:ro"
+sol_vnc_agent_extra_volumes: "{{ default_extra_volumes }}"
+
+####################
+# Per-DPU values (single source of truth for both config.yaml and nova [dpu])
+####################
+# These describe the BMC/IPMI of the physical host the BF3 DPU is plugged into
+# (not the DPU itself). bf3_host_ipmi_address differs per host and MUST be set
+# in inventory host_vars; the rest are usually shared (group_vars/compute-bf3).
+bf3_host_ipmi_username: "admin"
+bf3_host_ipmi_password: ""
+bf3_vnc_listen_port: 5900
+
+# Nova [dpu] driver options (rendered into the per-host nova override).
+bf3_compute_driver: "dpu.DPUIronicDriver"
+bf3_force_config_drive: true
+bf3_dpu_spdk_volume_bdev_type: "bdev_rbd"
+bf3_dpu_sf_ovs_offload_mode: "doca"
+
+####################
+# SOL-VNC screen / port settings (config.yaml)
+####################
+bf3_vnc_base_port: 5900
+bf3_vnc_max_nodes: 128
+bf3_vnc_screen_width: 1280
+bf3_vnc_screen_height: 800
+bf3_vnc_screen_depth: 24

--- a/ansible/roles/bf3/handlers/main.yml
+++ b/ansible/roles/bf3/handlers/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Restart sol-vnc-agent container
+  vars:
+    service_name: "sol-vnc-agent"
+    service: "{{ bf3_services[service_name] }}"
+  become: true
+  kolla_container:
+    action: "recreate_or_restart_container"
+    common_options: "{{ docker_common_options }}"
+    name: "{{ service.container_name }}"
+    image: "{{ service.image }}"
+    volumes: "{{ service.volumes | reject('equalto', '') | list }}"
+    dimensions: "{{ service.dimensions }}"
+    healthcheck: "{{ service.healthcheck | default(omit) }}"
+  when:
+    - kolla_action != "config"

--- a/ansible/roles/bf3/tasks/check-containers.yml
+++ b/ansible/roles/bf3/tasks/check-containers.yml
@@ -1,0 +1,17 @@
+---
+- name: Check bf3 containers
+  become: true
+  kolla_container:
+    action: "compare_container"
+    common_options: "{{ docker_common_options }}"
+    name: "{{ item.value.container_name }}"
+    image: "{{ item.value.image }}"
+    volumes: "{{ item.value.volumes | reject('equalto', '') | list }}"
+    dimensions: "{{ item.value.dimensions }}"
+    healthcheck: "{{ item.value.healthcheck | default(omit) }}"
+  when:
+    - inventory_hostname in groups[item.value.group]
+    - item.value.enabled | bool
+  with_dict: "{{ bf3_services }}"
+  notify:
+    - Restart {{ item.key }} container

--- a/ansible/roles/bf3/tasks/config.yml
+++ b/ansible/roles/bf3/tasks/config.yml
@@ -1,0 +1,27 @@
+---
+- import_tasks: nova-config.yml
+
+- name: Ensuring sol-vnc-agent config directory exists
+  become: true
+  file:
+    path: "{{ node_config_directory }}/{{ item.key }}"
+    state: "directory"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+    mode: "0770"
+  when:
+    - inventory_hostname in groups[item.value.group]
+    - item.value.enabled | bool
+  with_dict: "{{ bf3_services }}"
+
+- name: Copying over sol-vnc-agent config.yaml
+  become: true
+  template:
+    src: "config.yaml.j2"
+    dest: "{{ node_config_directory }}/sol-vnc-agent/config.yaml"
+    mode: "0660"
+  when:
+    - inventory_hostname in groups[bf3_group]
+    - bf3_services['sol-vnc-agent'].enabled | bool
+  notify:
+    - Restart sol-vnc-agent container

--- a/ansible/roles/bf3/tasks/deploy-containers.yml
+++ b/ansible/roles/bf3/tasks/deploy-containers.yml
@@ -1,0 +1,5 @@
+---
+- import_tasks: check-containers.yml
+
+- name: Flush handlers
+  meta: flush_handlers

--- a/ansible/roles/bf3/tasks/deploy.yml
+++ b/ansible/roles/bf3/tasks/deploy.yml
@@ -1,0 +1,7 @@
+---
+- import_tasks: config.yml
+
+- import_tasks: check-containers.yml
+
+- name: Flush handlers
+  meta: flush_handlers

--- a/ansible/roles/bf3/tasks/main.yml
+++ b/ansible/roles/bf3/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: "{{ kolla_action }}.yml"

--- a/ansible/roles/bf3/tasks/nova-config.yml
+++ b/ansible/roles/bf3/tasks/nova-config.yml
@@ -1,0 +1,24 @@
+---
+# Render the nova [dpu] override into the operator's custom-config tree on the
+# deploy node, so nova-cell's merge_configs picks it up. This file is owned by
+# the bf3 role for hosts in {{ bf3_group }} - it replaces the hand-maintained
+# /etc/kolla/config/nova/<host>/nova.conf for these DPU hosts.
+- name: Ensuring nova custom-config directory exists for BF3 DPU hosts
+  file:
+    path: "{{ node_custom_config }}/nova/{{ inventory_hostname }}"
+    state: "directory"
+    mode: "0770"
+  delegate_to: localhost
+  when:
+    - enable_bf3 | bool
+    - inventory_hostname in groups[bf3_group]
+
+- name: Rendering nova [dpu] config for BF3 DPU hosts
+  template:
+    src: "nova-dpu.conf.j2"
+    dest: "{{ node_custom_config }}/nova/{{ inventory_hostname }}/nova.conf"
+    mode: "0660"
+  delegate_to: localhost
+  when:
+    - enable_bf3 | bool
+    - inventory_hostname in groups[bf3_group]

--- a/ansible/roles/bf3/tasks/pull.yml
+++ b/ansible/roles/bf3/tasks/pull.yml
@@ -1,0 +1,3 @@
+---
+- import_role:
+    role: service-images-pull

--- a/ansible/roles/bf3/tasks/reconfigure.yml
+++ b/ansible/roles/bf3/tasks/reconfigure.yml
@@ -1,0 +1,2 @@
+---
+- import_tasks: deploy.yml

--- a/ansible/roles/bf3/tasks/stop.yml
+++ b/ansible/roles/bf3/tasks/stop.yml
@@ -1,0 +1,6 @@
+---
+- import_role:
+    name: service-stop
+  vars:
+    project_services: "{{ bf3_services }}"
+    service_name: "{{ project_name }}"

--- a/ansible/roles/bf3/templates/config.yaml.j2
+++ b/ansible/roles/bf3/templates/config.yaml.j2
@@ -1,0 +1,20 @@
+# SOL-VNC Agent config - managed by kolla-ansible (roles/bf3)
+# Nova get_vnc_console() returns DPU IP + vnc.port (this agent's listen port)
+
+bmc:
+  ip: {{ bf3_host_ipmi_address }}
+  user: {{ bf3_host_ipmi_username }}
+  password: {{ bf3_host_ipmi_password }}
+
+vnc:
+  base_port: {{ bf3_vnc_base_port }}
+  max_nodes: {{ bf3_vnc_max_nodes }}
+  # One SOL per DPU: fixed_port matches Nova [dpu] vnc_listen_port
+  fixed_port: {{ bf3_vnc_listen_port }}
+  screen:
+    width: {{ bf3_vnc_screen_width }}
+    height: {{ bf3_vnc_screen_height }}
+    depth: {{ bf3_vnc_screen_depth }}
+
+paths:
+  workdir: /var/run/sol-vnc

--- a/ansible/roles/bf3/templates/nova-dpu.conf.j2
+++ b/ansible/roles/bf3/templates/nova-dpu.conf.j2
@@ -1,0 +1,14 @@
+# Managed by kolla-ansible (roles/bf3). Merged into nova-compute's nova.conf
+# on hosts in the {{ bf3_group }} group when enable_bf3 is true.
+[DEFAULT]
+compute_driver = {{ bf3_compute_driver }}
+force_config_drive = {{ bf3_force_config_drive | bool | lower }}
+
+[dpu]
+ipmi_host = {{ bf3_host_ipmi_address }}
+ipmi_username = {{ bf3_host_ipmi_username }}
+ipmi_password = {{ bf3_host_ipmi_password }}
+enabled = true
+spdk_volume_bdev_type = {{ bf3_dpu_spdk_volume_bdev_type }}
+vnc_listen_port = {{ bf3_vnc_listen_port }}
+sf_ovs_offload_mode = {{ bf3_dpu_sf_ovs_offload_mode }}

--- a/ansible/roles/bf3/vars/main.yml
+++ b/ansible/roles/bf3/vars/main.yml
@@ -1,0 +1,2 @@
+---
+project_name: "bf3"

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -74,6 +74,7 @@
         - enable_zun_{{ enable_zun | bool }}
         - enable_zookeeper_{{ enable_zookeeper | bool }}
         - enable_dingo_command_{{ enable_dingo_command | bool }}
+        - enable_bf3_{{ enable_bf3 | bool }}
   tags: always
 
 - name: Apply role prechecks
@@ -712,6 +713,10 @@
   roles:
     - { role: ovn-db,
         tags: [ovn, ovn-db] }
+
+# BF3 DPU: deploy SOL-VNC agent and render nova [dpu] override. Must run before
+# nova.yml so nova-cell's merge_configs picks up the rendered override.
+- import_playbook: bf3.yml
 
 # Nova deployment is more complicated than other services, so is covered in its
 # own playbook.


### PR DESCRIPTION
Integrate the bf3 role into the 2025.1 (Epoxy) downstream branch:
  - ansible/roles/bf3: deploy sol-vnc-agent container, render nova [dpu] override into node_custom_config/nova/<host>/nova.conf for bf3_group hosts.
  - ansible/bf3.yml: imported from site.yml before nova.yml so nova-cell merge_configs picks up the override.
  - site.yml: add enable_bf3 to group_by list and import bf3.yml.
  - group_vars/all.yml: add enable_bf3 (default no).