### PR TITLE
fix(dingo-bear): proxy WebSocket upgrade for /v1/ws/ in nginx

### DIFF
--- a/ansible/roles/dingo-command/templates/dingo-bear/nginx.conf.j2
+++ b/ansible/roles/dingo-command/templates/dingo-bear/nginx.conf.j2
@@ -8,6 +8,21 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # WebSocket: cluster web terminal (/v1/ws/{cluster_id}). The plain /v1 proxy
+    # below drops the HTTP/1.1 Upgrade handshake, so the browser sees
+    # "WebSocket connection failed". More specific prefix wins, REST on /v1 untouched.
+    location /v1/ws/ {
+        proxy_pass http://127.0.0.1:38887;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+    }
+
     # Proxy API requests to FastAPI backend
     location /v1 {
         proxy_pass http://127.0.0.1:38887;


### PR DESCRIPTION
The cluster web terminal connects to /v1/ws/{cluster_id}, but the plain /v1 proxy drops the HTTP/1.1 Upgrade handshake, so the browser fails the WebSocket connection. Add a more-specific /v1/ws/ location with Upgrade/Connection headers; REST traffic on /v1 is unaffected.