### PR TITLE
同步 roce dhcp role sidecar bug fix 及注释更新

### DIFF
--- a/ansible/roles/roce-dhcp-dpu/files/roce_sidecar.py
+++ b/ansible/roles/roce-dhcp-dpu/files/roce_sidecar.py
@@ -214,6 +214,33 @@ def _load_state_from_db():
             time.sleep(delay)
             delay = min(delay * 2, 60)  # 5→10→20→40→60→60...
 
+def _is_instance_deleting(instance_uuid: str) -> bool:
+    """查 nova cell DB 判断实例是否真正被删除，而非关机/重启。
+
+    nova 删除实例时先把 task_state 设为 'deleting'（在调用 libvirt destroy 之前），
+    关机/重启时 task_state 是 'powering-off'/'rebooting' 等，借此区分。
+    DB 查询失败或实例记录不存在时返回 True（保守策略：允许清理）。
+    """
+    try:
+        db = _db()
+        with db.cursor() as c:
+            c.execute(
+                "SELECT task_state, deleted FROM instances WHERE uuid = %s",
+                (instance_uuid,)
+            )
+            row = c.fetchone()
+        db.close()
+        if row is None:
+            return True          # 记录不存在 → 已删除或从未写入
+        task_state, deleted = row
+        if deleted:
+            return True          # 已软删除
+        return task_state == 'deleting'
+    except Exception:
+        log.exception('_is_instance_deleting: nova DB 查询失败 uuid=%s', instance_uuid)
+        return True              # 查询失败时允许清理（保守策略）
+
+
 def _mask_to_prefix(mask_str: str) -> int:
     return bin(int.from_bytes(
         bytes(int(x) for x in mask_str.split('.')), 'big'
@@ -344,6 +371,17 @@ def register():
 def deregister(instance_uuid):
     # 冷迁移：caller_host 为源节点 IP/hostname，若 DB 已属于目标节点则跳过删除
     caller_host = request.args.get('caller_host', NODE_HOST)
+
+    # 关机/重启时 libvirt hook 也会触发 DELETE，但不应清理 DB。
+    # 查 nova instances.task_state：只有 'deleting'（nova delete 流程）才真正清理。
+    # ?force=1 绕过此检查，用于：管理员手动清理孤立记录、driver rollback 等场景。
+    force = request.args.get('force', '0') in ('1', 'true', 'yes')
+    if not force and not _is_instance_deleting(instance_uuid):
+        log.info('skip deregister uuid=%s: nova task_state != deleting（关机/重启，非删除）',
+                 instance_uuid)
+        return jsonify(ok=True, skipped=True,
+                       msg='nova instance is not being deleted'), 200
+
     try:
         db = _db()
         try:

--- a/ansible/roles/roce-dhcp/defaults/main.yml
+++ b/ansible/roles/roce-dhcp/defaults/main.yml
@@ -4,7 +4,7 @@ roce_dhcp_env_dir: /etc/kolla/roce-dhcp
 
 # eSwitch 模式：ROCE_PF 固定为 roce-dhcp（sidecar 监听 OVS internal port）
 # legacy 模式：填实际 PF 网卡名，如 ens7f1np1
-# host_vars/<host>.yml 中覆盖此值
+# 覆盖方式：在 /root/multinode 对应主机行内联 roce_dhcp_roce_pf=<value>（禁止用 host_vars）
 roce_dhcp_roce_pf: "roce-dhcp"
 
 # eSwitch 模式时 representor 和 roce-dhcp 所在的 OVS bridge

--- a/ansible/roles/roce-dhcp/files/db_init_fresh.sql
+++ b/ansible/roles/roce-dhcp/files/db_init_fresh.sql
@@ -1,4 +1,4 @@
--- RoCE DB 全新初始化（直接建 v3 正确 schema，跳过增量迁移）
+-- RoCE DB 全新初始化（直接建 v4 正确 schema，跳过增量迁移）
 -- 适用场景：全新环境首次部署（数据库中尚无 dpu_roce_* 表）
 -- 执行方式（在部署节点）：
 --   PASS=$(grep nova_database_password /etc/kolla/passwords.yml | awk '{print $2}')

--- a/ansible/roles/roce-dhcp/files/roce_sidecar.py
+++ b/ansible/roles/roce-dhcp/files/roce_sidecar.py
@@ -214,6 +214,33 @@ def _load_state_from_db():
             time.sleep(delay)
             delay = min(delay * 2, 60)  # 5→10→20→40→60→60...
 
+def _is_instance_deleting(instance_uuid: str) -> bool:
+    """查 nova cell DB 判断实例是否真正被删除，而非关机/重启。
+
+    nova 删除实例时先把 task_state 设为 'deleting'（在调用 libvirt destroy 之前），
+    关机/重启时 task_state 是 'powering-off'/'rebooting' 等，借此区分。
+    DB 查询失败或实例记录不存在时返回 True（保守策略：允许清理）。
+    """
+    try:
+        db = _db()
+        with db.cursor() as c:
+            c.execute(
+                "SELECT task_state, deleted FROM instances WHERE uuid = %s",
+                (instance_uuid,)
+            )
+            row = c.fetchone()
+        db.close()
+        if row is None:
+            return True          # 记录不存在 → 已删除或从未写入
+        task_state, deleted = row
+        if deleted:
+            return True          # 已软删除
+        return task_state == 'deleting'
+    except Exception:
+        log.exception('_is_instance_deleting: nova DB 查询失败 uuid=%s', instance_uuid)
+        return True              # 查询失败时允许清理（保守策略）
+
+
 def _mask_to_prefix(mask_str: str) -> int:
     return bin(int.from_bytes(
         bytes(int(x) for x in mask_str.split('.')), 'big'
@@ -344,6 +371,17 @@ def register():
 def deregister(instance_uuid):
     # 冷迁移：caller_host 为源节点 IP/hostname，若 DB 已属于目标节点则跳过删除
     caller_host = request.args.get('caller_host', NODE_HOST)
+
+    # 关机/重启时 libvirt hook 也会触发 DELETE，但不应清理 DB。
+    # 查 nova instances.task_state：只有 'deleting'（nova delete 流程）才真正清理。
+    # ?force=1 绕过此检查，用于：管理员手动清理孤立记录、driver rollback 等场景。
+    force = request.args.get('force', '0') in ('1', 'true', 'yes')
+    if not force and not _is_instance_deleting(instance_uuid):
+        log.info('skip deregister uuid=%s: nova task_state != deleting（关机/重启，非删除）',
+                 instance_uuid)
+        return jsonify(ok=True, skipped=True,
+                       msg='nova instance is not being deleted'), 200
+
     try:
         db = _db()
         try:


### PR DESCRIPTION
- roce_sidecar.py (compute/dpu): 修复关机/重启实例时 RoCE DB 记录被误删问题 deregister() 增加 _is_instance_deleting() 检查，仅 task_state='deleting' 时才清理 DB
- defaults/main.yml: 覆盖方式注释改为 multinode 内联，去掉旧的 host_vars 说法
- db_init_fresh.sql: 头注释更新为 v4 schema