### PR TITLE
fix: 修复 roce-dhcp 服务 systemd 依赖，解决节点重启后 DHCP 失效问题

### DIFF
--- a/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
@@ -73,6 +73,13 @@
             "dest": "/var/lib/kolla/share/ca-certificates",
             "owner": "root",
             "perm": "0600"
+        }{% endif %}{% if enable_roce_dhcp | default(false) | bool %},
+        {
+            "source": "{{ container_config_directory }}/hooks_qemu",
+            "dest": "/etc/libvirt/hooks/qemu",
+            "owner": "root",
+            "perm": "0755",
+            "optional": true
         }{% endif %}
     ]
 }

--- a/ansible/roles/roce-dhcp-dpu/templates/roce-dhcp-dpu.service.j2
+++ b/ansible/roles/roce-dhcp-dpu/templates/roce-dhcp-dpu.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=RoCE DHCP Sidecar (DPU, Docker)
-After=network.target docker.service openvswitch.service
+After=network.target docker.service ovs-vswitchd.service
 Requires=docker.service
 StartLimitBurst=5
 StartLimitIntervalSec=120
@@ -11,7 +11,7 @@ Restart=on-failure
 RestartSec=5s
 ExecStartPre=-/usr/bin/docker stop roce-dhcp
 ExecStartPre=-/usr/bin/docker rm roce-dhcp
-ExecStartPre=-/sbin/ip link set roce-dhcp up
+ExecStartPre=/sbin/ip link set roce-dhcp up
 ExecStart=/usr/bin/docker run --rm \
     --name roce-dhcp \
     --network=host \

--- a/ansible/roles/roce-dhcp/templates/hook_qemu.sh.j2
+++ b/ansible/roles/roce-dhcp/templates/hook_qemu.sh.j2
@@ -162,10 +162,10 @@ if [[ "$EVENT" == "prepare" && "$PHASE" == "begin" ]]; then
     # release/end 用此文件找到正确的 OVS port 名，避免产生 zombie port
     echo "$REP" > "/run/roce-hook-${INSTANCE_UUID}.rep"
 
-    # 2b. 设置 representor MTU 与 PF 一致（RoCE 需要大包，默认 1500 不够）
-    ip link set "$REP" mtu 9000 \
-        && _log "INFO $REP mtu=9000 配置成功" \
-        || _log "WARN $REP mtu 配置失败"
+    # 2b. 确保 representor UP 并设置 MTU（representor DOWN 会导致 VM 内 VF NO-CARRIER）
+    ip link set "$REP" up mtu 9000 \
+        && _log "INFO $REP up mtu=9000 配置成功" \
+        || _log "WARN $REP up/mtu 配置失败"
 
     ovs-vsctl set port "$REP" tag="$VLAN" vlan_mode=access \
         && _log "INFO $REP VLAN=$VLAN(access) 配置成功" \

--- a/ansible/roles/roce-dhcp/templates/roce-dhcp-container.service.j2
+++ b/ansible/roles/roce-dhcp/templates/roce-dhcp-container.service.j2
@@ -1,13 +1,14 @@
 [Unit]
 Description=RoCE DHCP Sidecar (container)
-After=network.target openvswitch.service
+After=network.target kolla-openvswitch_vswitchd-container.service
+Wants=kolla-openvswitch_vswitchd-container.service
 
 [Service]
 Type=simple
 Restart=on-failure
 RestartSec=5s
 ExecStartPre=-/usr/bin/podman rm -f roce-dhcp
-ExecStartPre=-/sbin/ip link set roce-dhcp up mtu 9000
+ExecStartPre=/sbin/ip link set roce-dhcp up mtu 9000
 ExecStartPre=-/usr/bin/podman exec openvswitch_vswitchd ovs-vsctl set interface roce-dhcp mtu_request=9000
 ExecStart=/usr/bin/podman run --rm \
     --name roce-dhcp \


### PR DESCRIPTION
计算节点：After=openvswitch.service 对应 unit 不存在（OVS 跑在 kolla Podman 容器 kolla-openvswitch_vswitchd-container.service 里），导致开机时 sidecar 先 于 OVS 启动，roce-dhcp 接口不存在，DHCP 静默失效。改为依赖真实 unit 并加
Wants=，去掉 ip link set 前的 - 使失败时 Restart=on-failure 能自动重试。

DPU 节点：openvswitch.service 同样不存在，改为依赖原生 ovs-vswitchd.service； ip link set 去掉 -（与节点实际文件对齐）。