### PR TITLE
fix: 首次部署新计算节点时 OVS port 创建移到 service 启动前

### DIFF
--- a/ansible/roles/roce-dhcp/tasks/deploy.yml
+++ b/ansible/roles/roce-dhcp/tasks/deploy.yml
@@ -2,6 +2,17 @@
 - include_tasks: pull.yml
 - include_tasks: config.yml
 
+- name: Ensure roce-dhcp internal port exists on OVS bridge
+  become: true
+  shell: |
+    OVS=$(which ovs-vsctl 2>/dev/null || echo "podman exec ovsdpdk_db ovs-vsctl")
+    $OVS list-ports {{ roce_dhcp_ovs_bridge }} | grep -qx roce-dhcp || \
+      $OVS add-port {{ roce_dhcp_ovs_bridge }} roce-dhcp \
+        -- set Interface roce-dhcp type=internal
+    ip link set roce-dhcp up
+  changed_when: false
+  when: roce_dhcp_roce_pf == 'roce-dhcp'
+
 - name: Install roce-dhcp-container systemd service
   become: true
   template:
@@ -52,14 +63,3 @@
     enabled: true
     state: started
     daemon_reload: true
-
-- name: Ensure roce-dhcp internal port exists on OVS bridge
-  become: true
-  shell: |
-    OVS=$(which ovs-vsctl 2>/dev/null || echo "podman exec ovsdpdk_db ovs-vsctl")
-    $OVS list-ports {{ roce_dhcp_ovs_bridge }} | grep -qx roce-dhcp || \
-      $OVS add-port {{ roce_dhcp_ovs_bridge }} roce-dhcp \
-        -- set Interface roce-dhcp type=internal
-    ip link set roce-dhcp up
-  changed_when: false
-  when: roce_dhcp_roce_pf == 'roce-dhcp'


### PR DESCRIPTION
原来 Ensure roce-dhcp internal port 任务排在 Enable and start 之后， f9c5f4d 去掉 ExecStartPre 的 - 前缀后，新节点首次部署必然失败。将 OVS port 创建任务前移，保证 ip link set roce-dhcp up 时 port 已存在。