### PR TITLE
chore: sync post-f2c dingoStack changes to dingoStack2025.1

### DIFF
--- a/ansible/roles/common/tasks/config.yml
+++ b/ansible/roles/common/tasks/config.yml
@@ -176,6 +176,7 @@
       - { name: "collectd", enabled: "{{ enable_collectd | bool }}" }
       - { name: "cyborg", enabled: "{{ enable_cyborg | bool }}" }
       - { name: "designate", enabled: "{{ enable_designate | bool }}" }
+      - { name: "dingo-command", enabled: "{{ enable_dingo_command | bool }}" }
       - { name: "etcd", enabled: "{{ enable_etcd | bool }}" }
       - { name: "fluentd", enabled: "{{ enable_fluentd | bool }}" }
       - { name: "glance", enabled: "{{ enable_glance | bool }}" }

--- a/ansible/roles/common/templates/cron-logrotate-dingo-command.conf.j2
+++ b/ansible/roles/common/templates/cron-logrotate-dingo-command.conf.j2
@@ -1,0 +1,3 @@
+"/var/log/kolla/dingo-command/*.log" "/var/log/kolla/dingo-command/*.err"
+{
+}

--- a/ansible/roles/dingo-command/templates/dingo-bear/deploy.sh.j2
+++ b/ansible/roles/dingo-command/templates/dingo-bear/deploy.sh.j2
@@ -26,8 +26,7 @@ mkdir -p /etc/kolla/dingo-bear /var/log/kolla/dingo-bear /var/lib/dingo-command
 run_args=(
   run -d
   --privileged
-  -p "${node_port}:${node_port}"
-  -p "${frontend_port}:${frontend_port}"
+  --network=host
   -e "SKYLINE_URL=${skyline_url}"
   -e "KOLLA_SKIP_ALEMBIC=1"
   -e "DINGO_RUN_SYNCERS={{ '1' if inventory_hostname == groups['dingo-bear'][0] else '0' }}"

--- a/ansible/roles/dingo-command/templates/dingo-bear/dingo-bear.conf.j2
+++ b/ansible/roles/dingo-command/templates/dingo-bear/dingo-bear.conf.j2
@@ -240,3 +240,11 @@ alert_platform_url = {{ alert_platform_url }}
 wecom_enabled = {{ dingo_bear_wecom_enabled }}
 # 企微群机器人 webhook。可填裸 key,也可填完整 webhook URL(会自动从 ?key= 提取)。空则不发,创建页可临时手填
 wecom_key = {{ dingo_bear_wecom_key }}
+
+[ib_probe]
+enabled = {{ dingo_bear_ib_probe_enabled }}
+interval = {{ dingo_bear_ib_probe_interval }}
+subnets = {{ dingo_bear_ib_probe_subnets }}
+interface = {{ dingo_bear_ib_probe_interface }}
+miss_threshold = {{ dingo_bear_ib_probe_miss_threshold }}
+evict_threshold = {{ dingo_bear_ib_probe_evict_threshold }}


### PR DESCRIPTION
## Summary

Sync the dingoStack changes after `f2c54f368` into `dingoStack2025.1`.

The target branch already contains the dingo-command/dingo-bear changes through its squash sync commit `21b3d16d0`, and the WeCom notification and metric-write changes also resolve to empty cherry-picks. This PR carries the two remaining changes:

- `a87f74472` Add logrotate configuration for dingo-command
- `c11b480a6` Add IPoIB reconcile config template

## Validation

- `git diff --check`
- YAML parse: `ansible/roles/common/tasks/config.yml`
- Jinja delimiter balance checks for all changed templates

Full tox/Ansible/yamllint suites were not run because those tools are not installed in the local environment.