### PR TITLE
feat(ovs-doca): add OVS-DOCA role for x86 control/compute nodes

### DIFF
--- a/ansible/deploy-ovs-doca.yml
+++ b/ansible/deploy-ovs-doca.yml
@@ -1,0 +1,31 @@
+---
+# OVS-DOCA 独立部署 playbook
+#
+# 适用范围：x86 节点（控制节点 / x86 计算节点）。BF3/DPU 不适用——
+# 那边用 globals.yml.dpu，其中 enable_openvswitch 为 no，下面的门控不成立。
+#
+# 常规部署请走 site.yml：在 globals.yml 设 enable_ovs_doca: "yes"，
+# 标准 openvswitch / ovs-dpdk role 自动跳过，改部署 DOCA OVS 容器；
+# 限定节点用 --limit：
+#   kolla-ansible deploy -i /root/multinode -t ovs-doca --limit <node>
+#
+# 本 playbook 仅用于不经 site.yml 单独重跑 ovs-doca role：
+#   kolla-ansible -i /root/multinode deploy-ovs-doca.yml [--limit <node>]
+#
+# 执行内容：
+#   1. 停止并禁用 kolla 原生 OVS 容器
+#   2. 清理 schema 不兼容的 conf.db（先备份）
+#   3. 启动 DOCA OVS 容器（ovs-doca-db + ovs-doca-vswitchd）
+#   4. 配置 hw-offload / doca-init / datapath_type
+#   5. 重建外部网桥并挂上联口
+#   6. 重启 ovn_controller 重新建立 br-int 和 Geneve 隧道
+#
+# 网卡 switchdev 模式与固件配置需在部署前预先固化，本 playbook 不负责。
+
+- hosts: control:compute-x86
+  gather_facts: true
+  become: true
+  tags: ovs-doca
+  roles:
+    - role: ovs-doca
+      when: (enable_openvswitch | bool) and (enable_ovs_doca | bool)

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1014,6 +1014,7 @@ enable_openvswitch: "{{ enable_neutron | bool and neutron_plugin_agent != 'linux
 enable_ovn: "{{ enable_neutron | bool and neutron_plugin_agent == 'ovn' }}"
 enable_ovn_sb_db_relay: "{{ enable_ovn | bool }}"
 enable_ovs_dpdk: "no"
+enable_ovs_doca: "no"
 enable_osprofiler: "no"
 enable_placement: "{{ enable_nova | bool or enable_zun | bool }}"
 enable_prometheus: "no"

--- a/ansible/roles/ovs-doca/defaults/main.yml
+++ b/ansible/roles/ovs-doca/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# ── 镜像 ──────────────────────────────────────────────────────────────────────
+# 镜像仓库取 kolla docker_registry 的 host:port 部分（去掉后面的 namespace 路径），
+# 与 build.sh push 的目标一致。站点可直接覆盖 ovs_doca_*_image 指定完整地址。
+ovs_doca_registry: "{{ docker_registry | default('') | regex_replace('/.*$', '') }}"
+ovs_doca_image_tag: "latest"
+ovs_doca_image_prefix: "{{ (ovs_doca_registry ~ '/') if ovs_doca_registry else '' }}"
+ovs_doca_db_image: "{{ ovs_doca_image_prefix }}ovs-doca-db:{{ ovs_doca_image_tag }}"
+ovs_doca_vswitchd_image: "{{ ovs_doca_image_prefix }}ovs-doca-vswitchd:{{ ovs_doca_image_tag }}"
+
+# ── 网桥与上联口 ──────────────────────────────────────────────────────────────
+# 默认沿用 kolla 原生变量，与标准 openvswitch role 指向同一个网桥/物理口
+ovs_doca_bridge: "{{ neutron_bridge_name }}"
+ovs_doca_uplink: "{{ neutron_external_interface }}"
+ovs_doca_bridge_fail_mode: "standalone"
+
+# datapath_type：system（兼容模式）或 doca（完整硬件卸载）
+# 首次部署建议先用 system 验证，再切换到 doca
+ovs_doca_datapath_type: "doca"
+
+# OVS hardware offload 相关配置（只在 datapath_type=doca 时有效）
+ovs_doca_hw_offload: "true"
+ovs_doca_doca_init: "true"
+
+# DOCA 版 OVS 的 ovsdb schema 版本。已有 conf.db 与此不符时会先备份再重建，
+# 因为 kolla 原生 OVS 与 DOCA OVS 的 schema 无法互相兼容。
+ovs_doca_db_schema_version: "8.5.1"
+
+# DB 数据卷路径（复用 kolla 现有 volume）
+ovs_doca_db_volume: "openvswitch_db"
+ovs_doca_logs_volume: "kolla_logs"

--- a/ansible/roles/ovs-doca/handlers/main.yml
+++ b/ansible/roles/ovs-doca/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: restart ovs-doca-db
+  systemd:
+    name: ovs-doca-db
+    state: restarted
+    daemon_reload: true
+
+- name: restart ovs-doca-vswitchd
+  systemd:
+    name: ovs-doca-vswitchd
+    state: restarted
+    daemon_reload: true

--- a/ansible/roles/ovs-doca/tasks/deploy.yml
+++ b/ansible/roles/ovs-doca/tasks/deploy.yml
@@ -1,0 +1,165 @@
+---
+# 网卡 switchdev 模式与固件相关配置在部署前预先固化，role 不负责。
+
+# ── 停止 kolla OVS 容器 ───────────────────────────────────────────────────────
+- name: Stop and disable kolla openvswitch containers
+  shell: |
+    # kolla 容器服务名因版本而异，两种命名都尝试
+    for svc in kolla-openvswitch_vswitchd-container kolla-openvswitch_db-container \
+               openvswitch_vswitchd openvswitch_db; do
+      if systemctl is-active --quiet $svc 2>/dev/null; then
+        systemctl stop $svc
+        systemctl disable $svc
+        echo "stopped $svc"
+      fi
+    done
+  changed_when: true
+
+# kolla 原生 OVS 与 DOCA OVS 的 ovsdb schema 版本不同且无法向下兼容，
+# 已有 conf.db 版本不符时必须备份后重建（期望版本见 ovs_doca_db_schema_version）
+- name: Check existing conf.db schema version
+  shell: |
+    DBFILE=/var/lib/containers/storage/volumes/{{ ovs_doca_db_volume }}/_data/conf.db
+    if [ -f "$DBFILE" ]; then
+      python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('schema_version','unknown'))" \
+        "$DBFILE" 2>/dev/null || echo "unreadable"
+    else
+      echo "notfound"
+    fi
+  register: db_schema_check
+  changed_when: false
+
+- name: Backup and remove incompatible conf.db
+  shell: |
+    DBFILE=/var/lib/containers/storage/volumes/{{ ovs_doca_db_volume }}/_data/conf.db
+    if [ -f "$DBFILE" ]; then
+      cp "$DBFILE" "${DBFILE}.bak.$(date +%Y%m%d%H%M%S)"
+      rm -f "$DBFILE"
+      echo "backed up and removed conf.db (schema {{ db_schema_check.stdout }})"
+    fi
+  when: db_schema_check.stdout not in ['notfound', ovs_doca_db_schema_version]
+  register: db_backup_result
+
+# ── 拉取 DOCA OVS 镜像 ────────────────────────────────────────────────────────
+- name: Pull DOCA OVS DB image
+  shell: podman pull --tls-verify=false {{ ovs_doca_db_image }}
+  register: pull_db
+  changed_when: "'Image is up to date' not in pull_db.stdout"
+
+- name: Pull DOCA OVS vswitchd image
+  shell: podman pull --tls-verify=false {{ ovs_doca_vswitchd_image }}
+  register: pull_vswitchd
+  changed_when: "'Image is up to date' not in pull_vswitchd.stdout"
+
+# ── 部署 systemd 服务 ─────────────────────────────────────────────────────────
+- name: Install ovs-doca-db systemd service
+  template:
+    src: ovs-doca-db.service.j2
+    dest: /etc/systemd/system/ovs-doca-db.service
+    mode: '0644'
+  notify: restart ovs-doca-db
+
+- name: Install ovs-doca-vswitchd systemd service
+  template:
+    src: ovs-doca-vswitchd.service.j2
+    dest: /etc/systemd/system/ovs-doca-vswitchd.service
+    mode: '0644'
+  notify: restart ovs-doca-vswitchd
+
+- name: Enable and start ovs-doca-db
+  systemd:
+    name: ovs-doca-db
+    enabled: true
+    state: started
+    daemon_reload: true
+
+- name: Wait for ovsdb socket to appear
+  wait_for:
+    path: /run/openvswitch/db.sock
+    timeout: 30
+
+- name: Enable and start ovs-doca-vswitchd
+  systemd:
+    name: ovs-doca-vswitchd
+    enabled: true
+    state: started
+    daemon_reload: true
+
+- name: Wait for ovs-vswitchd to be ready
+  shell: podman exec ovs-doca-vswitchd ovs-vsctl show
+  register: vswitchd_ready
+  retries: 15
+  delay: 2
+  until: vswitchd_ready.rc == 0
+
+# ── 配置 OVS datapath 和 hardware offload ─────────────────────────────────────
+- name: Set OVS datapath_type and hw-offload options
+  shell: |
+    OVS="podman exec ovs-doca-vswitchd ovs-vsctl"
+    $OVS set Open_vSwitch . \
+        other_config:hw-offload={{ ovs_doca_hw_offload }} \
+        other_config:doca-init={{ ovs_doca_doca_init }}
+  changed_when: true
+
+# ── 重建外部网桥 ──────────────────────────────────────────────────────────────
+- name: Check if external bridge already exists
+  shell: podman exec ovs-doca-vswitchd ovs-vsctl br-exists {{ ovs_doca_bridge }}
+  register: brex_exists
+  failed_when: false
+  changed_when: false
+
+- name: Create external bridge
+  shell: |
+    OVS="podman exec ovs-doca-vswitchd ovs-vsctl"
+    $OVS add-br {{ ovs_doca_bridge }}
+    $OVS set bridge {{ ovs_doca_bridge }} \
+        fail_mode={{ ovs_doca_bridge_fail_mode }} \
+        datapath_type={{ ovs_doca_datapath_type }}
+  when: brex_exists.rc != 0
+
+- name: Set datapath_type if external bridge already exists
+  shell: |
+    podman exec ovs-doca-vswitchd ovs-vsctl \
+      set bridge {{ ovs_doca_bridge }} datapath_type={{ ovs_doca_datapath_type }}
+  when: brex_exists.rc == 0
+  changed_when: true
+
+- name: Check if uplink already attached to external bridge
+  shell: |
+    podman exec ovs-doca-vswitchd ovs-vsctl list-ports {{ ovs_doca_bridge }} \
+      | grep -qx {{ ovs_doca_uplink }}
+  register: uplink_exists
+  failed_when: false
+  changed_when: false
+
+- name: Add uplink to external bridge
+  shell: |
+    podman exec ovs-doca-vswitchd ovs-vsctl \
+      add-port {{ ovs_doca_bridge }} {{ ovs_doca_uplink }}
+  when: uplink_exists.rc != 0
+
+# ── 重启 ovn_controller 重新建立 br-int 和 Geneve 隧道 ───────────────────────
+- name: Restart ovn_controller to repopulate br-int flows
+  shell: |
+    if systemctl is-active --quiet ovn_controller 2>/dev/null; then
+      systemctl restart ovn_controller
+    elif podman ps --filter name=ovn_controller --format '{{.Names}}' | grep -q ovn_controller; then
+      systemctl restart ovn_controller
+    fi
+  changed_when: true
+
+- name: Verify OVS-DOCA is running
+  shell: |
+    echo "=== OVS version ==="
+    podman exec ovs-doca-vswitchd ovs-vsctl --version | head -1
+    echo "=== bridge config ==="
+    podman exec ovs-doca-vswitchd ovs-vsctl list bridge {{ ovs_doca_bridge }} \
+      | grep -E "datapath_type|hw_offload|doca_init" || true
+    echo "=== other_config ==="
+    podman exec ovs-doca-vswitchd ovs-vsctl get Open_vSwitch . other_config
+  register: verify_out
+  changed_when: false
+
+- name: Show OVS-DOCA status
+  debug:
+    msg: "{{ verify_out.stdout_lines }}"

--- a/ansible/roles/ovs-doca/tasks/main.yml
+++ b/ansible/roles/ovs-doca/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: "{{ kolla_action | default('deploy') }}.yml"

--- a/ansible/roles/ovs-doca/templates/ovs-doca-db.service.j2
+++ b/ansible/roles/ovs-doca/templates/ovs-doca-db.service.j2
@@ -1,0 +1,27 @@
+[Unit]
+Description=OVS-DOCA ovsdb-server container
+After=network.target
+# kolla OVS 服务须已停止
+Conflicts=openvswitch_db.service
+
+[Service]
+Restart=always
+RestartSec=10
+ExecStartPre=-/usr/bin/podman rm -f ovs-doca-db
+ExecStart=/usr/bin/podman run \
+    --name ovs-doca-db \
+    --rm \
+    --network=host \
+    --privileged \
+    --cgroupns=host \
+    --cap-add=CAP_AUDIT_WRITE \
+    -v /var/lib/containers/storage/volumes/{{ ovs_doca_db_volume }}/_data:/var/lib/openvswitch:z \
+    -v /var/lib/containers/storage/volumes/{{ ovs_doca_logs_volume }}/_data:/var/log/kolla:z \
+    -v /run/openvswitch:/run/openvswitch:z \
+    -v /etc/localtime:/etc/localtime:ro \
+    {{ ovs_doca_db_image }}
+ExecStop=/usr/bin/podman stop ovs-doca-db
+TimeoutStopSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/ovs-doca/templates/ovs-doca-vswitchd.service.j2
+++ b/ansible/roles/ovs-doca/templates/ovs-doca-vswitchd.service.j2
@@ -1,0 +1,31 @@
+[Unit]
+Description=OVS-DOCA ovs-vswitchd container
+After=ovs-doca-db.service
+Requires=ovs-doca-db.service
+Conflicts=openvswitch_vswitchd.service
+
+[Service]
+Restart=always
+RestartSec=10
+ExecStartPre=-/usr/bin/podman rm -f ovs-doca-vswitchd
+ExecStartPre=-/sbin/ip link delete {{ ovs_doca_bridge }}
+ExecStartPre=-/sbin/ip link delete {{ ovs_doca_uplink }}
+ExecStart=/usr/bin/podman run \
+    --name ovs-doca-vswitchd \
+    --rm \
+    --network=host \
+    --privileged \
+    --cgroupns=host \
+    --security-opt label=disable \
+    -v /var/lib/containers/storage/volumes/{{ ovs_doca_logs_volume }}/_data:/var/log/kolla:z \
+    -v /run/openvswitch:/run/openvswitch:z \
+    -v /lib/modules:/lib/modules:ro \
+    -v /sys:/sys \
+    -v /dev:/dev \
+    -v /etc/localtime:/etc/localtime:ro \
+    {{ ovs_doca_vswitchd_image }}
+ExecStop=/usr/bin/podman stop ovs-doca-vswitchd
+TimeoutStopSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -59,7 +59,7 @@
         - enable_octavia_{{ enable_octavia | bool }}
         - enable_opensearch_{{ enable_opensearch | bool }}
         - enable_opensearch_dashboards_{{ enable_opensearch_dashboards | bool }}
-        - enable_openvswitch_{{ enable_openvswitch | bool }}_enable_ovs_dpdk_{{ enable_ovs_dpdk | bool }}
+        - enable_openvswitch_{{ enable_openvswitch | bool }}_enable_ovs_dpdk_{{ enable_ovs_dpdk | bool }}_enable_ovs_doca_{{ enable_ovs_doca | bool }}
         - enable_ovn_{{ enable_ovn | bool }}
         - enable_placement_{{ enable_placement | bool }}
         - enable_prometheus_{{ enable_prometheus | bool }}
@@ -658,7 +658,7 @@
   gather_facts: false
   hosts:
     - openvswitch
-    - '&enable_openvswitch_True_enable_ovs_dpdk_False'
+    - '&enable_openvswitch_True_enable_ovs_dpdk_False_enable_ovs_doca_False'
   serial: '{{ kolla_serial|default("0") }}'
   max_fail_percentage: >-
     {{ openvswitch_max_fail_percentage |
@@ -667,13 +667,13 @@
   roles:
     - { role: openvswitch,
         tags: openvswitch,
-        when: "(enable_openvswitch | bool) and not (enable_ovs_dpdk | bool)"}
+        when: "(enable_openvswitch | bool) and not (enable_ovs_dpdk | bool) and not (enable_ovs_doca | bool)"}
 
 - name: Apply role ovs-dpdk
   gather_facts: false
   hosts:
     - openvswitch
-    - '&enable_openvswitch_True_enable_ovs_dpdk_True'
+    - '&enable_openvswitch_True_enable_ovs_dpdk_True_enable_ovs_doca_False'
   serial: '{{ kolla_serial|default("0") }}'
   max_fail_percentage: >-
     {{ ovs_dpdk_max_fail_percentage |
@@ -682,7 +682,23 @@
   roles:
     - { role: ovs-dpdk,
         tags: ovs-dpdk,
-        when: "(enable_openvswitch | bool) and (enable_ovs_dpdk | bool)"}
+        when: "(enable_openvswitch | bool) and (enable_ovs_dpdk | bool) and not (enable_ovs_doca | bool)"}
+
+- name: Apply role ovs-doca
+  gather_facts: false
+  hosts:
+    - control
+    - compute-x86
+    - '&enable_openvswitch_True_enable_ovs_dpdk_False_enable_ovs_doca_True'
+  serial: '{{ kolla_serial|default("0") }}'
+  max_fail_percentage: >-
+    {{ ovs_doca_max_fail_percentage |
+       default(kolla_max_fail_percentage) |
+       default(100) }}
+  roles:
+    - { role: ovs-doca,
+        tags: ovs-doca,
+        when: "(enable_openvswitch | bool) and (enable_ovs_doca | bool)"}
 
 - name: Apply role ovn-controller
   gather_facts: false


### PR DESCRIPTION
新增 ovs-doca role，用 DOCA OVS 容器（ovs-doca-db + ovs-doca-vswitchd） 替代 kolla 原生 openvswitch 容器，支持 DOCA datapath 硬件卸载。

site.yml 按 ovs-dpdk 的范式接入：
- group_by 标签增加 enable_ovs_doca 维度
- openvswitch / ovs-dpdk 两个 play 增加 not enable_ovs_doca 排除， 启用 ovs-doca 时不再部署标准 OVS
- 新增 Apply role ovs-doca play，hosts 限定 control + compute-x86， BF3/DPU 不在范围内（那边 enable_openvswitch 为 no，门控也不成立）

用法：globals.yml 设 enable_ovs_doca: "yes"，限定节点用 --limit：
  kolla-ansible deploy -i <inventory> -t ovs-doca --limit <node>

role 变量全部取自 kolla 原生变量，不含站点相关硬编码：
- 镜像仓库取 docker_registry 的 host:port 段
- 网桥/上联口取 neutron_bridge_name / neutron_external_interface

同时修复 tasks/deploy.yml 中检查 conf.db schema 的任务：内嵌的多行 python 顶格书写，会提前终止 shell: | 块标量，导致整个 role 无法被
YAML 解析（PyYAML 与 ansible DataLoader 均报错）。改为单行 python -c 并将路径作为 argv 传入。